### PR TITLE
Updated bluebird version

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "chalk": "^0.5.1",
     "convict": "^1.0.1",
     "react-mixin": "3.0.4",
-    "superagent-bluebird-promise": "^3.0.0"
+    "superagent-bluebird-promise": "^4.1.0"
   },
   "main": "./src/components/index.js",
   "devDependencies": {


### PR DESCRIPTION
Extension installation failed due to out-dated bluebird version. This PR fixes the issue.

```
└─┬ mozaik-ext-json@0.0.11
  ├── UNMET PEER DEPENDENCY bluebird@2.x
  ├─┬ chalk@0.5.1
  │ ├── ansi-styles@1.1.0
  │ ├─┬ has-ansi@0.1.0
  │ │ └── ansi-regex@0.2.1
  │ ├── strip-ansi@0.3.0
  │ └── supports-color@0.2.0
  ├─┬ convict@1.5.0
  │ ├── depd@1.1.0
  │ ├── json5@0.5.0
  │ ├── lodash@4.16.2
  │ ├── minimist@1.2.0
  │ ├── moment@2.12.0
  │ ├── validator@4.6.1
  │ └─┬ varify@0.1.1
  │   └─┬ redeyed@0.4.4
  │     └── esprima@1.0.4
  └── superagent-bluebird-promise@2.1.1

npm WARN superagent-bluebird-promise@2.1.1 requires a peer of bluebird@2.x but none was installed.
```
